### PR TITLE
export TG_TF_PATH=terraform

### DIFF
--- a/zshrc.d/zshrc.cust
+++ b/zshrc.d/zshrc.cust
@@ -70,3 +70,6 @@ eval "$(pyenv init -)"
 # Add my keys to the ssh agent; passwords are pulled from the keychain.
 # The --apple-load-keychain option is unique to MacOS.
 ssh-add --apple-load-keychain
+
+# Terragrunt environment variables
+export TG_TF_PATH=terraform


### PR DESCRIPTION
specify terraform as the preferred tool for terragrunt in case OpenTofu and Terraform are both in PATH.